### PR TITLE
Fix markdown link to Libsodium

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Technical overview
 
 Kickpass is built around a shared library named libkickpass.
 
-libkickpass leverage [libsodium](https://github.com/jedisct1/libsodium/) to
-create safes.
+libkickpass leverage [libsodium](https://libsodium.org/) to create safes.
 
 Safes are created using authenticated encryption with associated data. As of
 now libkickpass use chacha20 along with poly1305 to encrypt and authenticate

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Technical overview
 
 Kickpass is built around a shared library named libkickpass.
 
-libkickpass leverage [https://github.com/jedisct1/libsodium/](libsodium) to
+libkickpass leverage [libsodium](https://github.com/jedisct1/libsodium/) to
 create safes.
 
 Safes are created using authenticated encryption with associated data. As of


### PR DESCRIPTION
Fix the the link on the text 'https://github.com/jedisct1/libsodium/' that redirects wrongly to https://github.com/paulfariello/kickpass/blob/develop/libsodium due to markdown syntax issue.