### PR TITLE
Add support for ssh-askpass

### DIFF
--- a/include/kickpass.h
+++ b/include/kickpass.h
@@ -42,7 +42,7 @@ struct kp_agent {
 struct kp_ctx {
 	char ws_path[PATH_MAX];
 	struct kp_agent agent;
-	kp_error_t (*password_cb)(struct kp_ctx *, const char *, bool, char *);
+	kp_error_t (*password_prompt)(struct kp_ctx *, const char *, bool, char *);
 	char * const password;
 	struct {
 		unsigned long long opslimit;

--- a/include/kickpass.h
+++ b/include/kickpass.h
@@ -42,7 +42,7 @@ struct kp_agent {
 struct kp_ctx {
 	char ws_path[PATH_MAX];
 	struct kp_agent agent;
-	kp_error_t (*password_cb)(struct kp_ctx *);
+	kp_error_t (*password_cb)(struct kp_ctx *, const char *, bool, char *);
 	char * const password;
 	struct {
 		unsigned long long opslimit;

--- a/lib/safe.c
+++ b/lib/safe.c
@@ -214,7 +214,7 @@ kp_safe_open(struct kp_ctx *ctx, struct kp_safe *safe, bool force)
 fallback:
 	if (ctx->password[0] == '\0') {
 		kp_error_t ret;
-		if ((ret = ctx->password_cb(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
+		if ((ret = ctx->password_prompt(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
 			return ret;
 		}
 	}
@@ -230,7 +230,7 @@ kp_safe_save(struct kp_ctx *ctx, struct kp_safe *safe)
 	/* XXX is it still required to test master password ? */
 	if (ctx->password[0] == '\0') {
 		kp_error_t ret;
-		if ((ret = ctx->password_cb(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
+		if ((ret = ctx->password_prompt(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
 			return ret;
 		}
 	}

--- a/lib/safe.c
+++ b/lib/safe.c
@@ -214,7 +214,7 @@ kp_safe_open(struct kp_ctx *ctx, struct kp_safe *safe, bool force)
 fallback:
 	if (ctx->password[0] == '\0') {
 		kp_error_t ret;
-		if ((ret = ctx->password_cb(ctx)) != KP_SUCCESS) {
+		if ((ret = ctx->password_cb(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
 			return ret;
 		}
 	}
@@ -230,7 +230,7 @@ kp_safe_save(struct kp_ctx *ctx, struct kp_safe *safe)
 	/* XXX is it still required to test master password ? */
 	if (ctx->password[0] == '\0') {
 		kp_error_t ret;
-		if ((ret = ctx->password_cb(ctx)) != KP_SUCCESS) {
+		if ((ret = ctx->password_cb(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
 			return ret;
 		}
 	}

--- a/src/command/create.c
+++ b/src/command/create.c
@@ -103,7 +103,7 @@ create(struct kp_ctx *ctx, int argc, char **argv)
 
 	/* Ask for password, otherwise it is asked on kp_safe_save which seems
 	 * weird for user */
-	if ((ret = ctx->password_cb(ctx)) != KP_SUCCESS) {
+	if ((ret = ctx->password_cb(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
 		return ret;
 	}
 
@@ -117,7 +117,7 @@ create(struct kp_ctx *ctx, int argc, char **argv)
 	if (generate) {
 		kp_password_generate(safe.password, password_len);
 	} else {
-		if ((ret = kp_prompt_password("safe", true, safe.password)) != KP_SUCCESS) {
+		if ((ret = ctx->password_cb(ctx, "safe", true, safe.password)) != KP_SUCCESS) {
 			goto out;
 		}
 	}

--- a/src/command/create.c
+++ b/src/command/create.c
@@ -103,7 +103,7 @@ create(struct kp_ctx *ctx, int argc, char **argv)
 
 	/* Ask for password, otherwise it is asked on kp_safe_save which seems
 	 * weird for user */
-	if ((ret = ctx->password_cb(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
+	if ((ret = ctx->password_prompt(ctx, "master", false, (char *)ctx->password)) != KP_SUCCESS) {
 		return ret;
 	}
 
@@ -117,7 +117,7 @@ create(struct kp_ctx *ctx, int argc, char **argv)
 	if (generate) {
 		kp_password_generate(safe.password, password_len);
 	} else {
-		if ((ret = ctx->password_cb(ctx, "safe", true, safe.password)) != KP_SUCCESS) {
+		if ((ret = ctx->password_prompt(ctx, "safe", true, safe.password)) != KP_SUCCESS) {
 			goto out;
 		}
 	}

--- a/src/command/edit.c
+++ b/src/command/edit.c
@@ -34,7 +34,7 @@
 
 static kp_error_t edit(struct kp_ctx *ctx, int argc, char **argv);
 static kp_error_t parse_opt(struct kp_ctx *, int, char **);
-static kp_error_t edit_password(struct kp_safe *);
+static kp_error_t edit_password(struct kp_ctx *, struct kp_safe *);
 static kp_error_t confirm_empty_password(bool *);
 static void usage(void);
 
@@ -78,7 +78,7 @@ edit(struct kp_ctx *ctx, int argc, char **argv)
 		if (generate) {
 			kp_password_generate(safe.password, password_len);
 		} else {
-			if ((ret = edit_password(&safe)) != KP_SUCCESS) {
+			if ((ret = edit_password(ctx, &safe)) != KP_SUCCESS) {
 				return ret;
 			}
 		}
@@ -102,7 +102,7 @@ edit(struct kp_ctx *ctx, int argc, char **argv)
 }
 
 static kp_error_t
-edit_password(struct kp_safe *safe)
+edit_password(struct kp_ctx *ctx, struct kp_safe *safe)
 {
 	kp_error_t ret = KP_SUCCESS;
 	char *password;
@@ -110,7 +110,7 @@ edit_password(struct kp_safe *safe)
 	bool confirm = true;
 
 	password = sodium_malloc(KP_PASSWORD_MAX_LEN);
-	if ((ret = kp_prompt_password("safe", true, password)) != KP_SUCCESS) {
+	if ((ret = ctx->password_cb(ctx, "safe", true, password)) != KP_SUCCESS) {
 		goto out;
 	}
 

--- a/src/command/edit.c
+++ b/src/command/edit.c
@@ -110,7 +110,7 @@ edit_password(struct kp_ctx *ctx, struct kp_safe *safe)
 	bool confirm = true;
 
 	password = sodium_malloc(KP_PASSWORD_MAX_LEN);
-	if ((ret = ctx->password_cb(ctx, "safe", true, password)) != KP_SUCCESS) {
+	if ((ret = ctx->password_prompt(ctx, "safe", true, password)) != KP_SUCCESS) {
 		goto out;
 	}
 

--- a/src/command/init.c
+++ b/src/command/init.c
@@ -41,7 +41,7 @@ init(struct kp_ctx *ctx, int argc, char **argv)
 {
 	kp_error_t ret;
 
-	kp_prompt_password("master", true, (char *)ctx->password);
+	ctx->password_cb(ctx, "master", true, (char *)ctx->password);
 
 	if ((ret = kp_init_workspace(ctx)) != KP_SUCCESS) {
 		return ret;

--- a/src/command/init.c
+++ b/src/command/init.c
@@ -41,7 +41,7 @@ init(struct kp_ctx *ctx, int argc, char **argv)
 {
 	kp_error_t ret;
 
-	ctx->password_cb(ctx, "master", true, (char *)ctx->password);
+	ctx->password_prompt(ctx, "master", true, (char *)ctx->password);
 
 	if ((ret = kp_init_workspace(ctx)) != KP_SUCCESS) {
 		return ret;

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,6 @@
 
 static int        cmd_cmp(const void *, const void *);
 static int        cmd_sort(const void *, const void *);
-static kp_error_t password_prompt(struct kp_ctx *);
 static kp_error_t command(struct kp_ctx *, int, char **);
 static kp_error_t help(struct kp_ctx *, int, char **);
 static kp_error_t parse_opt(struct kp_ctx *, int, char **);
@@ -110,12 +109,6 @@ static struct cmd cmds[] = {
 	{ "open",   &kp_cmd_open },
 };
 
-static kp_error_t
-password_prompt(struct kp_ctx *ctx)
-{
-	return kp_prompt_password("master", false, (char *)ctx->password);
-}
-
 /*
  * Parse command line and call matching command.
  * Most command are aliased and parse their own arguments.
@@ -128,7 +121,7 @@ main(int argc, char **argv)
 	char *socket_path = NULL;
 
 	kp_init(&ctx);
-	ctx.password_cb = password_prompt;
+	ctx.password_cb = kp_readpass;
 
 	if ((ret = parse_opt(&ctx, argc, argv)) != KP_SUCCESS) {
 		goto out;

--- a/src/main.c
+++ b/src/main.c
@@ -121,7 +121,7 @@ main(int argc, char **argv)
 	char *socket_path = NULL;
 
 	kp_init(&ctx);
-	ctx.password_cb = kp_readpass;
+	ctx.password_prompt = kp_readpass;
 
 	if ((ret = parse_opt(&ctx, argc, argv)) != KP_SUCCESS) {
 		goto out;

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -31,71 +31,97 @@
 #include "safe.h"
 #include "log.h"
 
+#define PASSWORD_PROMPT         "[kickpass] %s password: "
+#define PASSWORD_CONFIRM_PROMPT "[kickpass] confirm: "
+
+
 kp_error_t
 kp_askpass(struct kp_ctx *ctx, const char *type, bool confirm, char *password)
 {
-	char *askpass;
-	pid_t pid, ret;
-	size_t len;
-	int p[2], status;
-	void (*osigchld)(int);
+	kp_error_t ret = KP_SUCCESS;
+	char *prompt = NULL;
+	char *askpass = NULL;
+	char *output = NULL;
+	size_t len = 0;
+	pid_t pid;
+	int pipefd[2], status;
+	FILE *fout;
+	void (*sigchld_handler)(int);
 
 	if ((askpass = getenv("KP_ASKPASS")) == NULL) {
-		return KP_EINPUT;
+		askpass = "ssh-askpass";
 	}
 
 	if (fflush(stdout) != 0) {
 		return KP_ERRNO;
 	}
-	if (askpass == NULL) {
-		return KP_EINTERNAL;
-	}
-	if (pipe(p) < 0) {
+
+	if (pipe(pipefd) < 0) {
 		return KP_ERRNO;
 	}
-	osigchld = signal(SIGCHLD, SIG_DFL);
+
+	sigchld_handler = signal(SIGCHLD, SIG_DFL);
+
 	if ((pid = fork()) < 0) {
-		signal(SIGCHLD, osigchld);
-		return KP_ERRNO;
+		ret = KP_ERRNO;
+		goto out;
 	}
+
 	if (pid == 0) {
-		close(p[0]);
-		if (dup2(p[1], STDOUT_FILENO) < 0) {
-			kp_warn(KP_ERRNO, "kp_asskpass: dup2");
-			exit(1);
+		close(pipefd[0]);
+
+		if (dup2(pipefd[1], STDOUT_FILENO) < 0) {
+			kp_err(KP_ERRNO, "read stdout of %s", askpass);
 		}
-		execlp(askpass, askpass, type, (char *)NULL);
-		kp_warn(KP_ERRNO, "kp_asskpass: exec(%s)", askpass);
-		exit(1);
+
+		if (asprintf(&prompt, PASSWORD_PROMPT, type) < 0) {
+			kp_err(KP_ERRNO, "cannot build prompt");
+		}
+
+		execlp(askpass, askpass, prompt, (char *)NULL);
+
+		free(prompt);
+		close(pipefd[1]);
+		kp_err(KP_ERRNO, "cannot execute %s", askpass);
 	}
-	close(p[1]);
 
-	len = 0;
-	do {
-		ssize_t r = read(p[0], password + len,
-		    KP_PASSWORD_MAX_LEN - 1 - len);
-		if (r == -1 && errno == EINTR) {
-			continue;
-		}
-		if (r <= 0)
-			break;
-		len += r;
-	} while (KP_PASSWORD_MAX_LEN - 1 - len > 0);
-	password[len] = '\0';
-	close(p[0]);
+	close(pipefd[1]);
 
-	while ((ret = waitpid(pid, &status, 0)) < 0) {
+	if ((fout = fdopen(pipefd[0], "r")) == NULL) {
+		ret = KP_ERRNO;
+		kp_warn(ret, "cannot read password");
+		goto out;
+	}
+
+	if (getline(&output, &len, fout) < 0) {
+		ret = KP_ERRNO;
+		goto out;
+	}
+
+	while (waitpid(pid, &status, 0) < 0) {
 		if (errno != EINTR)
-			break;
+			goto out;
 	}
 
-	signal(SIGCHLD, osigchld);
-	if (ret == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-		memset(password, 0, KP_PASSWORD_MAX_LEN);
-		return KP_ERRNO;
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		goto out;
 	}
-	password[strcspn(password, "\r\n")] = '\0';
-	return KP_SUCCESS;
+
+	output[strcspn(output, "\r\n")] = '\0';
+	if (strlcpy(password, output, KP_PASSWORD_MAX_LEN)
+	    >= KP_PASSWORD_MAX_LEN) {
+		errno = ENAMETOOLONG;
+		ret = KP_ERRNO;
+		kp_warn(ret, "cannot read password");
+		goto out;
+	}
+
+
+out:
+	fclose(fout);
+	free(output);
+	signal(SIGCHLD, sigchld_handler);
+	return ret;
 }
 
 kp_error_t
@@ -103,26 +129,14 @@ kp_readpass(struct kp_ctx *ctx, const char *type, bool confirm, char *password)
 {
 	kp_error_t ret = KP_SUCCESS;
 	char *prompt = NULL;
-	size_t prompt_size;
 	char *confirmation = NULL;
 
 	assert(type);
 	assert(password);
 
-#define PASSWORD_PROMPT         "[kickpass] %s password: "
-#define PASSWORD_CONFIRM_PROMPT "[kickpass] confirm: "
-
-	/* Prompt is PASSWORD_PROMPT - '%s' + type + '\0' */
-	prompt_size = strlen(PASSWORD_PROMPT) - 2 + strlen(type) + 1;
-	prompt = malloc(prompt_size);
-	if (!prompt) {
-		errno = ENOMEM;
-		ret = KP_ERRNO;
-		kp_warn(ret, "memory error");
-		goto out;
+	if (asprintf(&prompt, PASSWORD_PROMPT, type) < 0) {
+		kp_err(KP_ERRNO, "cannot build prompt");
 	}
-
-	snprintf(prompt, prompt_size, PASSWORD_PROMPT, type);
 
 	if (readpassphrase(prompt, password, KP_PASSWORD_MAX_LEN,
 				RPP_ECHO_OFF | RPP_REQUIRE_TTY) == NULL) {

--- a/src/prompt.h
+++ b/src/prompt.h
@@ -23,6 +23,7 @@
 #include "error.h"
 #include "kickpass_config.h"
 
-kp_error_t kp_prompt_password(const char *, bool, char *);
+kp_error_t kp_readpass(struct kp_ctx *, const char *, bool, char *);
+kp_error_t kp_askpass(struct kp_ctx *, const char *, bool, char *);
 
 #endif /* KP_PROMPT_H */


### PR DESCRIPTION
Losely based on openssh code, add support for ssh-askpass programs
via the KP_ASKPASS env variable

It is useful when running kickpass without a real terminal