### PR TITLE
Fix spelling error

### DIFF
--- a/manual/kickpass.1
+++ b/manual/kickpass.1
@@ -162,7 +162,7 @@ Start a
 agent that will store your opened safe. Agent can be used by
 exporting
 .Ev KP_AGENT_SOCK
-environment variable. Optionnaly starts
+environment variable. Optionally starts
 .Ar command
 with the correct environment set.
 .Bl -tag -width flag

--- a/src/command/cat.c
+++ b/src/command/cat.c
@@ -113,7 +113,7 @@ parse_opt(struct kp_ctx *ctx, int argc, char **argv)
 
 	if (!password && metadata) {
 		kp_warnx(KP_EINPUT, "Opening only metadata is default behavior."
-				"You can ommit option.");
+				"You can omit option.");
 	}
 
 	/* Default open only metadata */

--- a/src/command/edit.c
+++ b/src/command/edit.c
@@ -217,7 +217,7 @@ parse_opt(struct kp_ctx *ctx, int argc, char **argv)
 
 	if (password && metadata) {
 		kp_warn(KP_EINPUT, "Editing both password and metadata"
-			       " is default behavior. You can ommit options.");
+			       " is default behavior. You can omit options.");
 	}
 
 	/* Default edit all */


### PR DESCRIPTION
This spelling errors were showed when I was trying to package kickpass to Debian.